### PR TITLE
Made the deployer set initial store owner

### DIFF
--- a/contracts/src/SaleSphere.sol
+++ b/contracts/src/SaleSphere.sol
@@ -3,10 +3,14 @@ pragma solidity 0.8.28;
 
 import { SalesStorage } from "./library/SalesStorage.sol";
 import { SalesContract } from "./SalesContract.sol";
-import { StaffManagement } from "./StaffMangement.sol";
+import { StaffManagement } from "./StaffManagement.sol";
 
 contract SaleSphere is SalesContract, StaffManagement {
     constructor(uint16 maxAdmins, uint16 productLowMargin) {
+        SalesStorage.StaffState storage staffState = SalesStorage.getStaffState();
+        staffState.deployer = msg.sender;
+
         SalesStorage.setInitials(maxAdmins, productLowMargin);
     }
 }
+

--- a/contracts/src/StaffMangement.sol
+++ b/contracts/src/StaffMangement.sol
@@ -13,6 +13,7 @@ contract StaffManagement {
     error InvalidRoleAssignment(uint256 staffID, SalesStorage.Role currentRole);
     error TooManyAdmins();
     error InvalidStaffID(uint256 staffID);
+    error NotDeployer();
 
     // Event to log important actions
     event StaffAdded(uint256 indexed staffID, address indexed staffAddr, string name, SalesStorage.Role role);
@@ -20,6 +21,28 @@ contract StaffManagement {
     event RoleUpdated(uint256 indexed staffID, address indexed staffAddr, SalesStorage.Role newRole);
     event AdminLimitUpdated(uint256 newLimit);
     event NewOwnerProposed(address proposedOwner);
+
+    // Function to set the initial store owner (can only be called by deployer)
+    function initialStoreOwner(address _storeOwner) external {
+        SalesStorage.StaffState storage staffState = SalesStorage.getStaffState();
+
+        // Only the deployer can call this function
+        if (msg.sender != staffState.deployer) {
+            revert NotDeployer();
+        }
+
+        // Ensure store owner is not already set
+        if (staffState.storeOwner != address(0)) {
+            revert("Store owner has already been set.");
+        }
+
+        // Ensure that the store owner isn't addressZero
+        if (_storeOwner == address(0)) {
+    revert("Invalid store owner address.");
+
+        // Set the store owner to the provided address
+        staffState.storeOwner = _storeOwner;
+    }
 
     // Function to update the max admin limit (only accessible by the store owner)
     function updateAdminLimit(uint16 _newLimit) public {

--- a/contracts/src/library/SalesStorage.sol
+++ b/contracts/src/library/SalesStorage.sol
@@ -78,15 +78,17 @@ library SalesStorage {
         Role role;
     }
 
-    struct StaffState {
-        uint16 maxAdmins; // Max number of admins allowed (set by store owner)
-        address storeOwner; // Store owner's address
-        address proposedOwner; // Proposed new owner
-        uint32 adminCount; // To track the number of administrators
-        mapping(address => Staff) staffDetails; // Mapping to store staff details by their address
-        mapping(uint256 => address) staffIDToAddress; // Mapping to store staffID to their address
-        address[] staffAddressArray; // Array of staffID
-    }
+   struct StaffState {
+    address deployer; // The address of the contract deployer
+    uint16 maxAdmins; // Max number of admins allowed (set by store owner)
+    address storeOwner; // Store owner's address
+    address proposedOwner; // Proposed new owner
+    uint32 adminCount; // To track the number of administrators
+    mapping(address => Staff) staffDetails; // Mapping to store staff details by their address
+    mapping(uint256 => address) staffIDToAddress; // Mapping to store staffID to their address
+    address[] staffAddressArray; // Array of staffID
+}
+
 
     // Function to retrieve staff storage
     function getStaffState() internal pure returns (StaffState storage staffState) {
@@ -98,11 +100,10 @@ library SalesStorage {
 
     function setInitials(uint16 maxAdmins, uint16 productLowMargin) internal {
         StaffState storage staffState = getStaffState();
-        staffState.storeOwner = msg.sender;
         staffState.maxAdmins = maxAdmins;
 
         StoreState storage state = getStoreState();
-        state.productLowMargin = productLowMargin;
+        state.productLowMargin = productLowMargin;  
     }
 
     function deleteStaffIDFromArray(address _staffAddr) internal {


### PR DESCRIPTION
The deployer is now responsible for setting the initial store owner upon contract deployment, separating the deployer and store owner roles.